### PR TITLE
Update to 1.21.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,13 +16,13 @@ java_version=21
 # Fabric Properties
 # check these on https://fabricmc.net/develop/
 # Dependencies
-minecraft_version=1.21.8
-yarn_mappings=1.21.8+build.1
+minecraft_version=1.21.9
+yarn_mappings=1.21.9+build.1
 loader_version=0.17.2
 loom_version=1.11-SNAPSHOT
 
 # Fabric API
-fabric_version=0.133.0+1.21.8
+fabric_version=0.134.0+1.21.9
 
 # Loom image source
 #loom_libraries_base=https://bmclapi2.bangbang93.com/maven/

--- a/src/main/java/com/github/bunnyi116/bedrockminer/util/ClientPlayerInteractionManagerUtils.java
+++ b/src/main/java/com/github/bunnyi116/bedrockminer/util/ClientPlayerInteractionManagerUtils.java
@@ -72,7 +72,7 @@ public class ClientPlayerInteractionManagerUtils {  // 璇ョ被鏄负鍚庣画寮�鍙戝
                 }
                 BlockState blockState = world.getBlockState(pos);
                 client.getTutorialManager().onBlockBreaking(world, pos, blockState, 0.0F);
-                var calcBlockBreakingDelta = blockState.calcBlockBreakingDelta(player, player.getWorld(), pos);
+                var calcBlockBreakingDelta = blockState.calcBlockBreakingDelta(player, player.getEntityWorld(), pos);
                 if (calcBlockBreakingDelta >= BREAKING_PROGRESS_MAX) {
                     sendSequencedPacket((sequence) -> {
                         if (!blockState.isAir()) {
@@ -118,7 +118,7 @@ public class ClientPlayerInteractionManagerUtils {  // 璇ョ被鏄负鍚庣画寮�鍙戝
                 breakingBlock = false;
                 return false;
             } else {
-                currentBreakingProgress += blockState.calcBlockBreakingDelta(player, player.getWorld(), pos);
+                currentBreakingProgress += blockState.calcBlockBreakingDelta(player, player.getEntityWorld(), pos);
                 if (blockBreakingSoundCooldown % 4.0F == 0.0F) {
                     BlockSoundGroup blockSoundGroup = blockState.getSoundGroup();
                     client.getSoundManager().play(new PositionedSoundInstance(blockSoundGroup.getHitSound(), SoundCategory.BLOCKS, (blockSoundGroup.getVolume() + 1.0F) / 8.0F, blockSoundGroup.getPitch() * 0.5F, SoundInstance.createRandom(), pos));


### PR DESCRIPTION
`net.minecraft.client.network.ClientPlayerEntity.getWorld()` no longer exists. I replaced it with `.getEntityWorld()`.
Bedrock breaking works locally and on servers.